### PR TITLE
Re-trigger After Success By Administrator

### DIFF
--- a/test_cases.md
+++ b/test_cases.md
@@ -1,0 +1,8 @@
+## Re-trigger After Success
+
+### By Administrator
+ - [T] makes a pull request
+ - [T] tags for test
+ - [R] reports sucessful test
+ - [A] re-triggers test
+ - [R] doesn't recognize admin as valid re-tagger after success, doesn't re-run test


### PR DESCRIPTION
 - [T] makes a pull request
 - [T] tags for test
 - [R] reports sucessful test
 - [A] re-triggers test
 - [R] doesn't recognize admin as valid re-tagger after success, doesn't re-run test

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>