### PR TITLE
Re-trigger After Failure By Trusted User With Flake Comment Without Jenkins Job Link

### DIFF
--- a/test_cases.md
+++ b/test_cases.md
@@ -1,0 +1,11 @@
+## Re-trigger After Failure
+
+### By Trusted User With Flake Comment
+
+#### Without Jenkins Job Link
+ - [T] makes a pull request
+ - [T] tags for test
+ - [R] reports failed test
+ - [T] reports flake issue without Jenkins link
+ - [T] re-triggers test
+ - [R] pastes error message, does not trigger test


### PR DESCRIPTION
 - [T] makes a pull request
 - [T] tags for test
 - [R] reports failed test
 - [T] reports flake issue without Jenkins link
 - [T] re-triggers test
 - [R] pastes error message, does not trigger test

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>