### PR TITLE
Pull request against old base commit id is merged properly

### DIFF
--- a/test_cases.md
+++ b/test_cases.md
@@ -1,0 +1,5 @@
+## Local merge pull request merges against correct base commit id when specified
+
+### By User
+ - [U] makes PR against old base repo/branch commit id
+ - [U] runs something like `test_pull_requests --repo test-pull-requests-redshirt --local_merge_pull_request 14 --base_commit b34b691adfd31666c0e325c303451df090ce8646 --config tpr_redshirt.json`


### PR DESCRIPTION
`test_pull_requests --local_merge_pull_request <pull_id> --base_commit <commit_id>` merges against correct revision of base repo instead of most recent when old commit id is reference in PR and specified on command line.